### PR TITLE
[CHORES] fix update_version workflow

### DIFF
--- a/.github/workflows/update_version.yaml
+++ b/.github/workflows/update_version.yaml
@@ -59,6 +59,7 @@ jobs:
         run: |
           for BRANCH in $TARGET_BRANCHES; do
             echo "Pushing version update to $BRANCH branch..."
+            git fetch origin $BRANCH
             git push origin HEAD:$BRANCH
           done
 


### PR DESCRIPTION
It should now be able to push to branches below it